### PR TITLE
System optimizations for serving

### DIFF
--- a/inference/Dockerfile.staging
+++ b/inference/Dockerfile.staging
@@ -1,0 +1,18 @@
+# inference/Dockerfile.staging
+
+FROM python:3.10-slim
+
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Set environment variable for MLflow
+ENV MLFLOW_TRACKING_URI=http://129.114.25.37:8000
+
+# Copy inference code (including your inference_api.py)
+COPY . .
+
+# Run FastAPI server (adjust this if your API file is named differently)
+CMD ["uvicorn", "inference_api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/inference/docker-compose-inference.yml
+++ b/inference/docker-compose-inference.yml
@@ -44,6 +44,7 @@ services:
       - "8005:8002"   # Triton Metrics
     volumes:
       - ./models/music_rec:/models/music_rec
+      - ./evaluation:/evaluation:ro
     networks:
       - mlops-network
 

--- a/inference/docker-compose-inference.yml
+++ b/inference/docker-compose-inference.yml
@@ -48,6 +48,31 @@ services:
     networks:
       - mlops-network
 
+  prometheus:
+    image: prom/prometheus
+    container_name: prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    networks:
+      - mlops-network
+
+  grafana:
+    image: grafana/grafana
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana-storage:/var/lib/grafana
+    depends_on:
+      - prometheus
+    networks:
+      - mlops-network
+  
 networks:
   mlops-network:
     external: true 
+
+volumes:
+  grafana-storage:

--- a/inference/docker-compose-inference.yml
+++ b/inference/docker-compose-inference.yml
@@ -10,6 +10,8 @@ services:
       - "8080:8080"
     volumes:
       - /mnt/object:/mnt/object
+      # Mount the model for use by Triton
+      - ./models/music_rec:/models/music_rec:ro
     networks:
       - mlops-network
     environment:
@@ -19,6 +21,31 @@ services:
       - AWS_SECRET_ACCESS_KEY=hrwbqzUS85G253yKi43T
       - AWS_DEFAULT_REGION=us-east-1
       - S3_ENDPOINT_URL=http://129.114.25.37:9000
+      - TRITON_SERVER_URL=http://triton:8000
+      - USE_TRITON=true
+    depends_on:
+      - triton
+
+  # === 2) Triton Inference Server ===
+  triton:
+    image: nvcr.io/nvidia/tritonserver:24.03-py3
+    container_name: triton
+    runtime: nvidia
+    command: >
+      tritonserver
+        --model-repository=/models
+        --log-verbose=1
+    environment:
+
+      - NVIDIA_VISIBLE_DEVICES=0
+    ports:
+      - "8003:8000"   # Triton HTTP
+      - "8004:8001"   # Triton gRPC
+      - "8005:8002"   # Triton Metrics
+    volumes:
+      - ./models/music_rec:/models/music_rec
+    networks:
+      - mlops-network
 
 networks:
   mlops-network:

--- a/inference/evaluation/gen_input.py
+++ b/inference/evaluation/gen_input.py
@@ -1,0 +1,17 @@
+# gen_input.py
+import json
+import numpy as np
+
+# Generate a dummy 128-dimensional embedding vector and write to input.json
+
+# 1) Create a random vector of length 128
+emb = np.random.rand(128).tolist()
+
+# 2) Build the payload
+payload = {"embeddings": emb}
+
+# 3) Write to input.json
+with open("input.json", "w") as f:
+    json.dump(payload, f)
+
+print("Generated input.json with length:", len(emb))

--- a/inference/evaluation/gen_real_examples.py
+++ b/inference/evaluation/gen_real_examples.py
@@ -1,0 +1,19 @@
+# inference/evaluation/gen_real_examples.py
+import json
+import random
+import os
+
+TRACK_TEXT_PATH = "/mnt/block/processed/track_texts.json"
+OUTPUT_PATH = "inference/evaluation/example_tracks.json"
+
+def generate_example_samples(n=20):
+    with open(TRACK_TEXT_PATH, "r", encoding="utf-8") as f:
+        track_map = json.load(f)
+
+    samples = [{"text": t} for t in random.sample(list(track_map.values()), k=min(n, len(track_map)))]
+    with open(OUTPUT_PATH, "w", encoding="utf-8") as out_f:
+        json.dump(samples, out_f, indent=2, ensure_ascii=False)
+    print(f"✅ Saved {len(samples)} track samples to {OUTPUT_PATH}")
+
+if __name__ == "__main__":
+    generate_example_samples(n=20)

--- a/inference/evaluation/post.lua
+++ b/inference/evaluation/post.lua
@@ -1,0 +1,4 @@
+-- post.lua
+wrk.method = "POST"
+wrk.headers["Content-Type"] = "application/json"
+wrk.body = io.open("input.json", "r"):read("*a")

--- a/inference/evaluation/prepare_data.py
+++ b/inference/evaluation/prepare_data.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from sklearn.model_selection import train_test_split
 
 # Reuse the llara_train.py data-loading functions
-from llara_train import (
+from train.llara_train import (
     load_embeddings_from_mlflow,
     load_playlist_data,
     create_training_pairs

--- a/inference/evaluation/run_bensh.sh
+++ b/inference/evaluation/run_bensh.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -e
+cd "$(dirname "$0")"
+
+# --- Triton queue vs compute latency tests ---
+echo ">>> Triton Perf Analyzer Tests"
+for c in 1 4 8 16; do
+  echo "-- concurrency = $c --"
+  docker exec triton perf_analyzer \
+    -u localhost:8005 \
+    -m music_rec \
+    --input-data /evaluation/input.json \
+    -b 1 \
+    --concurrency-range $c \
+    --percentiles=50,95,99
+  echo
+done
+
+# --- FastAPI throughput tests via wrk ---
+echo ">>> FastAPI wrk Benchmark"
+API="http://localhost:8080/predict"
+for c in 1 4 8 16; do
+  echo "-- concurrency = $c --"
+  wrk -t$c -c$c -d20s -s post.lua $API
+  echo
+done
+
+# --- GPU utilization snapshot ---
+echo ">>> GPU Utilization (nvidia-smi)"
+docker exec triton nvidia-smi

--- a/inference/evaluation/simulate_users.py
+++ b/inference/evaluation/simulate_users.py
@@ -1,0 +1,31 @@
+# inference/evaluation/simulate_users.py
+import os
+import json
+import time
+import random
+import requests
+
+FASTAPI_URL = os.getenv("FASTAPI_URL", "http://localhost:8080/predict")
+EXAMPLE_PATH = "inference/evaluation/example_tracks.json"
+
+with open(EXAMPLE_PATH, "r", encoding="utf-8") as f:
+    EXAMPLE_TRACKS = json.load(f)
+
+def simulate_request(track_texts):
+    payload = {"tracks": track_texts}
+    response = requests.post(FASTAPI_URL, json=payload)
+    try:
+        res_json = response.json()
+        print(f"Response: {res_json['request_id']} => {res_json['predictions'][:3]}...")
+    except Exception as e:
+        print(f"Failed to decode response: {e}")
+
+def simulate_users(rounds=5, delay=5):
+    print(f"🚀 Sending {rounds} simulated requests to {FASTAPI_URL}...")
+    for i in range(rounds):
+        sampled_tracks = random.sample(EXAMPLE_TRACKS, k=random.randint(1, 3))
+        simulate_request(sampled_tracks)
+        time.sleep(delay)
+
+if __name__ == "__main__":
+    simulate_users(rounds=20, delay=2)

--- a/inference/export_onnx.py
+++ b/inference/export_onnx.py
@@ -1,40 +1,66 @@
 #!/usr/bin/env python3
-# inference/export_onnx_local.py
+# inference/export_onnx.py
 
-import os, sys, torch
+import os
+import sys
+import torch
+import mlflow
 
-# 确保能 import 到你的模型定义
+# 1) Ensure we can import your model definition from train/llara_train.py
 proj_root = os.path.abspath(os.path.join(__file__, "..", ".."))
 if proj_root not in sys.path:
     sys.path.insert(0, proj_root)
-from train.llara_train import LlaRAClassifier
+from train.llara_train import get_latest_run_id, LlaRAClassifier
 
-pt_path = "models/music_rec/1/llara_model.pt"
-if not os.path.exists(pt_path):
-    raise FileNotFoundError(pt_path)
+# 2) Configure MLflow to point at your remote Tracking Server and MinIO
+os.environ["MLFLOW_TRACKING_URI"]    = "http://129.114.25.37:8000"
+os.environ["MLFLOW_S3_ENDPOINT_URL"] = "http://129.114.25.37:9000"
+os.environ["AWS_ACCESS_KEY_ID"]      = "admin"
+os.environ["AWS_SECRET_ACCESS_KEY"]  = "hrwbqzUS85G253yKi43T"
 
-# 1) load checkpoint
-ckpt = torch.load(pt_path, map_location="cpu", weights_only=False)
-in_dim   = ckpt["input_dim"]
-num_cls  = ckpt["num_classes"]
-hid_dim  = ckpt.get("hidden_dim", 512)
-drop     = ckpt.get("dropout", 0.3)
-state    = ckpt["model_state"]
+# 3) Retrieve the latest successful run of the llara-classifier experiment
+run_id = get_latest_run_id("llara-classifier")
+print(f"Exporting ONNX from MLflow run {run_id}")
 
-# 2) rebuild model
-model = LlaRAClassifier(in_dim, num_cls, hid_dim, drop)
-model.load_state_dict(state)
+# 4) Load the logged PyTorch model via MLflow’s PyTorch flavor
+#    Note: `models/llara_model` matches the artifact path used in mlflow.log_artifact(...)
+model_uri = f"runs:/{run_id}/models/llara_model"
+model = mlflow.pytorch.load_model(model_uri)
 model.eval()
+print("Model loaded from MLflow")
 
-# 3) export ONNX
-out_dir = os.path.dirname(pt_path)
-onnx_path = os.path.join(out_dir, "model.onnx")
-dummy = torch.randn(1, in_dim)
+# 5) Determine the input dimension by inspecting the first Linear layer
+#    (assumes your LlaRAClassifier has at least one nn.Linear module)
+import torch.nn as nn
+input_dim = None
+for module in model.modules():
+    if isinstance(module, nn.Linear):
+        input_dim = module.in_features
+        break
+if input_dim is None:
+    raise RuntimeError("Could not infer input_dim from model architecture")
+print(f"Inferred input_dim = {input_dim}")
+
+# 6) Export the model to ONNX format
+output_dir = "models/music_rec/1"
+os.makedirs(output_dir, exist_ok=True)
+onnx_path = os.path.join(output_dir, "model.onnx")
+
+# Create a dummy tensor with the correct input shape
+dummy_input = torch.randn(1, input_dim)
+
+# Perform the export
 torch.onnx.export(
-    model, dummy, onnx_path,
+    model,
+    dummy_input,
+    onnx_path,
     input_names=["input_embeddings"],
     output_names=["scores"],
     opset_version=13,
-    dynamic_axes={"input_embeddings":{0:"batch"}, "scores":{0:"batch"}},
+    dynamic_axes={
+        "input_embeddings": {0: "batch"},
+        "scores":           {0: "batch"},
+    },
 )
-print(f"✅ ONNX saved to {onnx_path}")
+print(f"ONNX model saved to {onnx_path}")
+

--- a/inference/export_onnx.py
+++ b/inference/export_onnx.py
@@ -1,37 +1,56 @@
 #!/usr/bin/env python3
-# inference/export_onnx_local.py
+# inference/export_onnx.py
 
-import os, sys, torch
+import os
+import sys
+import torch
+import mlflow
+from mlflow.tracking import MlflowClient
 
-# —— import 你们的模型定义 —— 
+# —— 如果你的 MLflow Server 配置了 Artifact HTTP 代理，确保先设 URI —— 
+mlflow.set_tracking_uri("http://129.114.25.37:8000/")
+
+# —— 为了能 import 你们的训练脚本，插入项目根到 sys.path —— 
 proj_root = os.path.abspath(os.path.join(__file__, "..", ".."))
-sys.path.insert(0, proj_root)
-from train.llara_train import LlaRAClassifier  # 模型类
+if proj_root not in sys.path:
+    sys.path.insert(0, proj_root)
+from train.llara_train import get_latest_run_id
 
-# 1) 本地 .pt 路径
-pt_path = "models/music_rec/1/llara_model.pt"
-ckpt = torch.load(pt_path, map_location="cpu")
+# 1) 找到最新 Run
+run_id = get_latest_run_id("llara-classifier")
+print(f"🔍 Loading LLaRA model from MLflow run {run_id}")
 
-# 2) 重建模型并 load
-in_dim   = ckpt["input_dim"]
-num_cls  = ckpt["num_classes"]
-hid_dim  = ckpt.get("hidden_dim", 512)
-drop     = ckpt.get("dropout", 0.3)
-state    = ckpt["model_state"]
-
-model = LlaRAClassifier(in_dim, num_cls, hid_dim, drop)
-model.load_state_dict(state)
+# 2) 用 PyTorch Flavor 接口加载模型  
+#    model_uri 的格式是 "runs:/<run_id>/<artifact_path_without_suffix>"
+#    训练时你是 mlflow.log_artifact(model_path, "models"),
+#    那么这里就是 "models/llara_model"
+model_uri = f"runs:/{run_id}/models/llara_model"
+model = mlflow.pytorch.load_model(model_uri)
 model.eval()
+print("✅ Model loaded:", model)
 
-# 3) 导出 ONNX
-out_dir = os.path.dirname(pt_path)
+# 3) 从模型结构里自动推断 input_dim（取第一个 Linear 层的输入维度）
+first_linear = next(m for m in model.modules() if isinstance(m, torch.nn.Linear))
+input_dim = first_linear.in_features
+print(f"ℹ️  Detected input_dim = {input_dim}")
+
+# 4) 导出成 ONNX
+out_dir = os.path.abspath("models/music_rec/1")
+os.makedirs(out_dir, exist_ok=True)
 onnx_path = os.path.join(out_dir, "model.onnx")
-dummy = torch.randn(1, in_dim)
+
+# 构造一个 dummy 输入
+dummy_input = torch.randn(1, input_dim)
 torch.onnx.export(
-    model, dummy, onnx_path,
+    model,
+    dummy_input,
+    onnx_path,
     input_names=["input_embeddings"],
     output_names=["scores"],
     opset_version=13,
-    dynamic_axes={"input_embeddings":{0:"batch"}, "scores":{0:"batch"}}
+    dynamic_axes={
+        "input_embeddings": {0: "batch"},
+        "scores":           {0: "batch"},
+    },
 )
-print(f"✅ ONNX saved to {onnx_path}")
+print(f"✅ ONNX model saved to {onnx_path}")

--- a/inference/export_onnx.py
+++ b/inference/export_onnx.py
@@ -1,48 +1,66 @@
 #!/usr/bin/env python3
-# inference/export_onnx.py
+# inference/export_onnx_direct.py
 
-import os, sys, torch, mlflow
-from mlflow.tracking import MlflowClient
+import os
+import sys
+import boto3
+import torch
+import tempfile
 
-# —— 如果你需要走 MinIO，也把 env 放最前 —— 
-os.environ["MLFLOW_S3_ENDPOINT_URL"] = "http://129.114.25.37:9000"
-os.environ["AWS_ACCESS_KEY_ID"]      = "admin"
-os.environ["AWS_SECRET_ACCESS_KEY"]  = "hrwbqzUS85G253yKi43T"
-
-# 确保能 import train.llara_train
+# —— 让脚本能够 import train/llara_train.py —— 
 proj_root = os.path.abspath(os.path.join(__file__, "..", ".."))
 sys.path.insert(0, proj_root)
-from train.llara_train import LlaRAClassifier, get_latest_run_id
+from train.llara_train import LlaRAClassifier  # 只需模型类
 
-# 1) 找到最新 Run
-mlflow.set_tracking_uri("http://129.114.25.37:8000/")
-run_id = get_latest_run_id("llara-classifier")
-print(f"Loading model via MLflow PyTorch flavor from run {run_id}")
+# 1) MinIO S3 配置（和训练时一致）
+MINIO_ENDPOINT = "http://129.114.25.37:9000"
+AWS_ACCESS_KEY_ID = "admin"
+AWS_SECRET_ACCESS_KEY = "hrwbqzUS85G253yKi43T"
+BUCKET = "mlflow-artifacts"
 
-# 2) 用 mlflow.pytorch.load_model 直接加载
-model_uri = f"runs:/{run_id}/models/llara_model"
-model = mlflow.pytorch.load_model(model_uri)  # 返回一个 torch.nn.Module
-model.eval()
+# 2) 运行 ID & 存储路径
+RUN_ID = "a497978bf50a43fe89e780f9e0591479"  # 你的 Run ID
+# 从你给的路径看，模型对象 key 是：
+KEY = f"4/{RUN_ID}/artifacts/models/llara_model.pt"
 
-# 如果你想确认类型：
-print("Loaded model:", model)
+# 3) 在临时目录下载 .pt
+with tempfile.TemporaryDirectory() as tmp:
+    local_pt = os.path.join(tmp, "llara_model.pt")
 
-# 3) 导出 ONNX
-#    需要知道 input_dim，取自 model.net[0].in_features
-#    下面假设你的 classifier 用 Sequential，第一个是 Linear
-first_lin = next(m for m in model.modules() if isinstance(m, torch.nn.Linear))
-input_dim = first_lin.in_features
+    s3 = boto3.client(
+        "s3",
+        endpoint_url=MINIO_ENDPOINT,
+        aws_access_key_id=AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
+    )
+    print(f"⬇️  Downloading s3://{BUCKET}/{KEY} → {local_pt}")
+    s3.download_file(BUCKET, KEY, local_pt)
+    print("✅ Download complete")
 
-onnx_dir = os.path.abspath("models/music_rec/1")
-os.makedirs(onnx_dir, exist_ok=True)
-onnx_path = os.path.join(onnx_dir, "model.onnx")
+    # 4) Load checkpoint
+    ckpt = torch.load(local_pt, map_location="cpu")
+    in_dim   = ckpt["input_dim"]
+    num_cls  = ckpt["num_classes"]
+    hid_dim  = ckpt.get("hidden_dim", 512)
+    drop     = ckpt.get("dropout", 0.3)
+    state    = ckpt["model_state"]
 
-dummy = torch.randn(1, input_dim)
-torch.onnx.export(
-    model, dummy, onnx_path,
-    input_names=["input_embeddings"],
-    output_names=["scores"],
-    opset_version=13,
-    dynamic_axes={"input_embeddings":{0:"batch"}, "scores":{0:"batch"}}
-)
-print(f"✅ ONNX model saved to {onnx_path}")
+    # 5) Rebuild & load model
+    model = LlaRAClassifier(in_dim, num_cls, hid_dim, drop)
+    model.load_state_dict(state)
+    model.eval()
+
+    # 6) Export ONNX
+    out_dir = os.path.abspath("models/music_rec/1")
+    os.makedirs(out_dir, exist_ok=True)
+    onnx_path = os.path.join(out_dir, "model.onnx")
+
+    dummy = torch.randn(1, in_dim)
+    torch.onnx.export(
+        model, dummy, onnx_path,
+        input_names=["input_embeddings"],
+        output_names=["scores"],
+        opset_version=13,
+        dynamic_axes={"input_embeddings": {0: "batch"}, "scores": {0: "batch"}},
+    )
+    print(f"✅ ONNX model saved to {onnx_path}")

--- a/inference/export_onnx.py
+++ b/inference/export_onnx.py
@@ -14,7 +14,7 @@ if not os.path.exists(pt_path):
     raise FileNotFoundError(pt_path)
 
 # 1) load checkpoint
-ckpt = torch.load(pt_path, map_location="cpu")
+ckpt = torch.load(pt_path, map_location="cpu", weights_only=False)
 in_dim   = ckpt["input_dim"]
 num_cls  = ckpt["num_classes"]
 hid_dim  = ckpt.get("hidden_dim", 512)

--- a/inference/export_onnx.py
+++ b/inference/export_onnx.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+# inference/export_onnx.py
+
+import os
+import mlflow
+import torch
+import tempfile
+from llara_train import LlaRAClassifier, get_latest_run_id
+
+# 1) Configure MLflow
+MLFLOW_TRACKING_URI = os.getenv("MLFLOW_TRACKING_URI", "http://129.114.25.37:8000/")
+mlflow.set_tracking_uri(MLFLOW_TRACKING_URI)
+
+# 2) Find the latest run for the LLaRA experiment
+run_id = get_latest_run_id("llara-classifier")
+print(f"Exporting ONNX from MLflow run {run_id}")
+
+# 3) Download exactly the llara_model.pt artifact
+with tempfile.TemporaryDirectory() as tmp:
+    pt_path = mlflow.artifacts.download_artifacts(
+        run_id=run_id,
+        artifact_path="models/llara_model.pt",
+        dst_path=tmp
+    )
+
+    # 4) Load checkpoint
+    ckpt = torch.load(pt_path, map_location="cpu")
+    input_dim   = ckpt["input_dim"]
+    num_classes = ckpt["num_classes"]
+    hidden_dim  = ckpt.get("hidden_dim", 512)
+    dropout     = ckpt.get("dropout", 0.3)
+    state_dict  = ckpt["model_state"]
+
+    # 5) Reconstruct model and load weights
+    model = LlaRAClassifier(input_dim, num_classes, hidden_dim, dropout)
+    model.load_state_dict(state_dict)
+    model.eval()
+
+    # 6) Export to ONNX
+    onnx_dir = os.path.abspath("models/music_rec/1")
+    os.makedirs(onnx_dir, exist_ok=True)
+    onnx_path = os.path.join(onnx_dir, "model.onnx")
+
+    dummy = torch.randn(1, input_dim)
+    torch.onnx.export(
+        model,
+        dummy,
+        onnx_path,
+        input_names=["input_embeddings"],
+        output_names=["scores"],
+        opset_version=13,
+        dynamic_axes={
+            "input_embeddings": {0: "batch"},
+            "scores":           {0: "batch"}
+        }
+    )
+
+    print(f"ONNX model successfully saved to {onnx_path}")

--- a/inference/export_onnx.py
+++ b/inference/export_onnx.py
@@ -5,8 +5,13 @@ import os
 import mlflow
 import torch
 import tempfile
-from llara_train import LlaRAClassifier, get_latest_run_id
+import sys
 
+proj_root = os.path.abspath(os.path.join(__file__, "..", ".."))
+if proj_root not in sys.path:
+    sys.path.insert(0, proj_root)
+
+from train.llara_train import LlaRAClassifier, get_latest_run_id
 # 1) Configure MLflow
 MLFLOW_TRACKING_URI = os.getenv("MLFLOW_TRACKING_URI", "http://129.114.25.37:8000/")
 mlflow.set_tracking_uri(MLFLOW_TRACKING_URI)

--- a/inference/export_onnx.py
+++ b/inference/export_onnx.py
@@ -1,49 +1,37 @@
 #!/usr/bin/env python3
-# inference/export_onnx.py
+# inference/export_onnx_local.py
 
-import os, sys, torch, mlflow
+import os, sys, torch
 
-# —— 让脚本能 import 到 train/llara_train.py —— 
+# —— import 你们的模型定义 —— 
 proj_root = os.path.abspath(os.path.join(__file__, "..", ".."))
-if proj_root not in sys.path:
-    sys.path.insert(0, proj_root)
+sys.path.insert(0, proj_root)
+from train.llara_train import LlaRAClassifier  # 模型类
 
-from train.llara_train import LlaRAClassifier, get_latest_run_id
+# 1) 本地 .pt 路径
+pt_path = "models/music_rec/1/llara_model.pt"
+ckpt = torch.load(pt_path, map_location="cpu")
 
-# 1) 先设置 Tracking URI （只针对 HTTP 下载）
-mlflow.set_tracking_uri("http://129.114.25.37:8000/")
+# 2) 重建模型并 load
+in_dim   = ckpt["input_dim"]
+num_cls  = ckpt["num_classes"]
+hid_dim  = ckpt.get("hidden_dim", 512)
+drop     = ckpt.get("dropout", 0.3)
+state    = ckpt["model_state"]
 
-# 2) 找到最新的 run
-run_id = get_latest_run_id("llara-classifier")
-print(f"🔍 Loading model from MLflow run {run_id}")
-
-# 3) 用 MLflow 的 PyTorch flavor 接口直接加载模型
-#    这里的 "models/llara_model" 对应你 training 脚本里 mlflow.log_artifact(model_path, "models")
-model_uri = f"runs:/{run_id}/models/llara_model"
-model = mlflow.pytorch.load_model(model_uri)  # 返回 torch.nn.Module
+model = LlaRAClassifier(in_dim, num_cls, hid_dim, drop)
+model.load_state_dict(state)
 model.eval()
 
-print("✅ Model loaded:", model)
-
-# 4) 导出 ONNX
-#    自动从模型结构里找到输入维度
-#    假定第一个 Linear 层是 input_dim
-first_lin = next(m for m in model.modules() if isinstance(m, torch.nn.Linear))
-input_dim = first_lin.in_features
-
-out_dir = os.path.abspath("models/music_rec/1")
-os.makedirs(out_dir, exist_ok=True)
+# 3) 导出 ONNX
+out_dir = os.path.dirname(pt_path)
 onnx_path = os.path.join(out_dir, "model.onnx")
-
-dummy = torch.randn(1, input_dim)
+dummy = torch.randn(1, in_dim)
 torch.onnx.export(
     model, dummy, onnx_path,
     input_names=["input_embeddings"],
     output_names=["scores"],
     opset_version=13,
-    dynamic_axes={
-        "input_embeddings": {0: "batch"},
-        "scores":           {0: "batch"},
-    }
+    dynamic_axes={"input_embeddings":{0:"batch"}, "scores":{0:"batch"}}
 )
-print(f"✅ ONNX model saved to {onnx_path}")
+print(f"✅ ONNX saved to {onnx_path}")

--- a/inference/export_onnx.py
+++ b/inference/export_onnx.py
@@ -1,56 +1,40 @@
 #!/usr/bin/env python3
-# inference/export_onnx.py
+# inference/export_onnx_local.py
 
-import os
-import sys
-import torch
-import mlflow
-from mlflow.tracking import MlflowClient
+import os, sys, torch
 
-# —— 如果你的 MLflow Server 配置了 Artifact HTTP 代理，确保先设 URI —— 
-mlflow.set_tracking_uri("http://129.114.25.37:8000/")
-
-# —— 为了能 import 你们的训练脚本，插入项目根到 sys.path —— 
+# 确保能 import 到你的模型定义
 proj_root = os.path.abspath(os.path.join(__file__, "..", ".."))
 if proj_root not in sys.path:
     sys.path.insert(0, proj_root)
-from train.llara_train import get_latest_run_id
+from train.llara_train import LlaRAClassifier
 
-# 1) 找到最新 Run
-run_id = get_latest_run_id("llara-classifier")
-print(f"🔍 Loading LLaRA model from MLflow run {run_id}")
+pt_path = "models/music_rec/1/llara_model.pt"
+if not os.path.exists(pt_path):
+    raise FileNotFoundError(pt_path)
 
-# 2) 用 PyTorch Flavor 接口加载模型  
-#    model_uri 的格式是 "runs:/<run_id>/<artifact_path_without_suffix>"
-#    训练时你是 mlflow.log_artifact(model_path, "models"),
-#    那么这里就是 "models/llara_model"
-model_uri = f"runs:/{run_id}/models/llara_model"
-model = mlflow.pytorch.load_model(model_uri)
+# 1) load checkpoint
+ckpt = torch.load(pt_path, map_location="cpu")
+in_dim   = ckpt["input_dim"]
+num_cls  = ckpt["num_classes"]
+hid_dim  = ckpt.get("hidden_dim", 512)
+drop     = ckpt.get("dropout", 0.3)
+state    = ckpt["model_state"]
+
+# 2) rebuild model
+model = LlaRAClassifier(in_dim, num_cls, hid_dim, drop)
+model.load_state_dict(state)
 model.eval()
-print("✅ Model loaded:", model)
 
-# 3) 从模型结构里自动推断 input_dim（取第一个 Linear 层的输入维度）
-first_linear = next(m for m in model.modules() if isinstance(m, torch.nn.Linear))
-input_dim = first_linear.in_features
-print(f"ℹ️  Detected input_dim = {input_dim}")
-
-# 4) 导出成 ONNX
-out_dir = os.path.abspath("models/music_rec/1")
-os.makedirs(out_dir, exist_ok=True)
+# 3) export ONNX
+out_dir = os.path.dirname(pt_path)
 onnx_path = os.path.join(out_dir, "model.onnx")
-
-# 构造一个 dummy 输入
-dummy_input = torch.randn(1, input_dim)
+dummy = torch.randn(1, in_dim)
 torch.onnx.export(
-    model,
-    dummy_input,
-    onnx_path,
+    model, dummy, onnx_path,
     input_names=["input_embeddings"],
     output_names=["scores"],
     opset_version=13,
-    dynamic_axes={
-        "input_embeddings": {0: "batch"},
-        "scores":           {0: "batch"},
-    },
+    dynamic_axes={"input_embeddings":{0:"batch"}, "scores":{0:"batch"}},
 )
-print(f"✅ ONNX model saved to {onnx_path}")
+print(f"✅ ONNX saved to {onnx_path}")

--- a/inference/export_onnx.py
+++ b/inference/export_onnx.py
@@ -1,70 +1,48 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # inference/export_onnx.py
 
-import os
+import os, sys, torch, mlflow
+from mlflow.tracking import MlflowClient
 
-# 指定 MLflow artifact store（MinIO）的 endpoint 和凭证
+# —— 如果你需要走 MinIO，也把 env 放最前 —— 
 os.environ["MLFLOW_S3_ENDPOINT_URL"] = "http://129.114.25.37:9000"
 os.environ["AWS_ACCESS_KEY_ID"]      = "admin"
 os.environ["AWS_SECRET_ACCESS_KEY"]  = "hrwbqzUS85G253yKi43T"
-import mlflow
-import torch
-import tempfile
-import sys
 
+# 确保能 import train.llara_train
 proj_root = os.path.abspath(os.path.join(__file__, "..", ".."))
-if proj_root not in sys.path:
-    sys.path.insert(0, proj_root)
-
+sys.path.insert(0, proj_root)
 from train.llara_train import LlaRAClassifier, get_latest_run_id
-# 1) Configure MLflow
-MLFLOW_TRACKING_URI = os.getenv("MLFLOW_TRACKING_URI", "http://129.114.25.37:8000/")
-mlflow.set_tracking_uri(MLFLOW_TRACKING_URI)
 
-# 2) Find the latest run for the LLaRA experiment
+# 1) 找到最新 Run
+mlflow.set_tracking_uri("http://129.114.25.37:8000/")
 run_id = get_latest_run_id("llara-classifier")
-print(f"Exporting ONNX from MLflow run {run_id}")
+print(f"Loading model via MLflow PyTorch flavor from run {run_id}")
 
-with tempfile.TemporaryDirectory() as tmp:
-    # 只指定到 models 目录
-    local_models_dir = mlflow.artifacts.download_artifacts(
-        run_id=run_id,
-        artifact_path="models",
-        dst_path=tmp
-    )
-    # local_models_dir = /tmp/tmpXXXX/models
-    print("Downloaded to:", local_models_dir)
-    print("Contents:", os.listdir(local_models_dir))
-    
-    # 构造 .pt 文件的完整路径
-    pt_path = os.path.join(local_models_dir, "llara_model.pt")
-    if not os.path.exists(pt_path):
-        raise FileNotFoundError(f"{pt_path} not found after download")
+# 2) 用 mlflow.pytorch.load_model 直接加载
+model_uri = f"runs:/{run_id}/models/llara_model"
+model = mlflow.pytorch.load_model(model_uri)  # 返回一个 torch.nn.Module
+model.eval()
 
-    # 加载 checkpoint
-    ckpt = torch.load(pt_path, map_location="cpu")
-    input_dim   = ckpt["input_dim"]
-    num_classes = ckpt["num_classes"]
-    hidden_dim  = ckpt.get("hidden_dim", 512)
-    dropout     = ckpt.get("dropout", 0.3)
-    state_dict  = ckpt["model_state"]
+# 如果你想确认类型：
+print("Loaded model:", model)
 
-    # 重建模型并 load
-    model = LlaRAClassifier(input_dim, num_classes, hidden_dim, dropout)
-    model.load_state_dict(state_dict)
-    model.eval()
+# 3) 导出 ONNX
+#    需要知道 input_dim，取自 model.net[0].in_features
+#    下面假设你的 classifier 用 Sequential，第一个是 Linear
+first_lin = next(m for m in model.modules() if isinstance(m, torch.nn.Linear))
+input_dim = first_lin.in_features
 
-    # 导出 ONNX
-    onnx_dir = os.path.abspath("models/music_rec/1")
-    os.makedirs(onnx_dir, exist_ok=True)
-    onnx_path = os.path.join(onnx_dir, "model.onnx")
+onnx_dir = os.path.abspath("models/music_rec/1")
+os.makedirs(onnx_dir, exist_ok=True)
+onnx_path = os.path.join(onnx_dir, "model.onnx")
 
-    dummy = torch.randn(1, input_dim)
-    torch.onnx.export(
-        model, dummy, onnx_path,
-        input_names=["input_embeddings"],
-        output_names=["scores"],
-        opset_version=13,
-        dynamic_axes={"input_embeddings": {0: "batch"}, "scores": {0: "batch"}}
-    )
-    print(f"✅ ONNX model saved to {onnx_path}")
+dummy = torch.randn(1, input_dim)
+torch.onnx.export(
+    model, dummy, onnx_path,
+    input_names=["input_embeddings"],
+    output_names=["scores"],
+    opset_version=13,
+    dynamic_axes={"input_embeddings":{0:"batch"}, "scores":{0:"batch"}}
+)
+print(f"✅ ONNX model saved to {onnx_path}")

--- a/inference/export_onnx.py
+++ b/inference/export_onnx.py
@@ -2,6 +2,11 @@
 # inference/export_onnx.py
 
 import os
+
+# 指定 MLflow artifact store（MinIO）的 endpoint 和凭证
+os.environ["MLFLOW_S3_ENDPOINT_URL"] = "http://129.114.25.37:9000"
+os.environ["AWS_ACCESS_KEY_ID"]      = "admin"
+os.environ["AWS_SECRET_ACCESS_KEY"]  = "hrwbqzUS85G253yKi43T"
 import mlflow
 import torch
 import tempfile

--- a/inference/inference_api.py
+++ b/inference/inference_api.py
@@ -1,18 +1,22 @@
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
-from fastapi import Request
-import json
+
 import os
+import json
 import mlflow
 import boto3
 from datetime import datetime
 import sys
 import torch
+import numpy as np 
 from transformers import DistilBertTokenizer
+
 sys.path.append('/app')
 from data_processing.data_preprocess import process_data
+
+from tritonclient.http import InferenceServerClient, InferInput, InferRequestedOutput
 
 app = FastAPI(title="Music Recommendation")
 
@@ -20,12 +24,21 @@ app = FastAPI(title="Music Recommendation")
 app.mount("/static", StaticFiles(directory="static"), name="static")
 templates = Jinja2Templates(directory="templates")
 
+# Flag to switch Triton on/off via environment variable
+USE_TRITON = os.getenv("USE_TRITON", "true").lower() == "true"
+
+# Initialize Triton client if enabled
+if USE_TRITON:
+    TRITON_URL = os.getenv("TRITON_SERVER_URL", "http://triton:8000")
+    triton_client = InferenceServerClient(url=TRITON_URL)
+
 # Initialize MLflow client
 mlflow.set_tracking_uri("http://0.0.0.0:8000")
 client = mlflow.tracking.MlflowClient()
 
 # Initialize MinIO client
-s3_client = boto3.client('s3',
+s3_client = boto3.client(
+    's3',
     endpoint_url='http://minio:9000',
     aws_access_key_id='admin',
     aws_secret_access_key='hrwbqzUS85G253yKi43T'
@@ -34,99 +47,126 @@ s3_client = boto3.client('s3',
 # Initialize BERT tokenizer
 tokenizer = DistilBertTokenizer.from_pretrained('distilbert-base-uncased')
 
+
 def get_latest_model_run():
     """Get the latest model run ID from MLflow"""
     experiments = client.search_experiments()
     latest_run = None
     latest_run_id = None
-    
+
     for exp in experiments:
         runs = client.search_runs(exp.experiment_id)
         for run in runs:
             if latest_run is None or run.info.run_id > latest_run_id:
                 latest_run = run
                 latest_run_id = run.info.run_id
-    
+
     return latest_run
+
 
 def load_models(run_id):
     """Load all models from the latest run"""
     models = {}
-    # Load BERT model
-    models['bert'] = mlflow.pytorch.load_model(f"runs:/{run_id}/models/bert_model")
-    # Load Matrix Factorization model
-    models['mf'] = mlflow.sklearn.load_model(f"runs:/{run_id}/models/mf_model")
-    # Load MLP model
-    models['mlp'] = mlflow.pytorch.load_model(f"runs:/{run_id}/models/mlp_projector")
-    # Load LLARA model
+    models['bert']  = mlflow.pytorch.load_model(f"runs:/{run_id}/models/bert_model")
+    models['mf']    = mlflow.sklearn.load_model(f"runs:/{run_id}/models/mf_model")
+    models['mlp']   = mlflow.pytorch.load_model(f"runs:/{run_id}/models/mlp_projector")
     models['llara'] = mlflow.pytorch.load_model(f"runs:/{run_id}/models/llara_model")
     return models
+
 
 @app.get("/")
 async def read_root(request: Request):
     """Serve the main page"""
     return templates.TemplateResponse("index.html", {"request": request})
 
+
 @app.post("/predict")
 async def predict(request: Request):
     """Handle prediction requests"""
     try:
-        # Get JSON data from request
+        # 1. Receive and save raw input JSON
         data = await request.json()
-        
-        # Generate unique ID for this request
         request_id = datetime.now().strftime("%Y%m%d_%H%M%S")
-        
-        # Save input JSON
         input_path = f"/mnt/object/inference/input_{request_id}.json"
         with open(input_path, 'w') as f:
             json.dump(data, f)
-        
-        # Process data
-        processed_files = process_data(input_path)
-        
-        # Get latest model run
+
+        # 2. Preprocess input data
+        processed_dir = "/mnt/object/processed_data"
+        process_data(input_path, processed_dir, quick=False)
+
+        # 3. Fetch latest MLflow run and load models
         latest_run = get_latest_model_run()
         if not latest_run:
             raise HTTPException(status_code=500, detail="No models found in MLflow")
-        
-        # Load models
         models = load_models(latest_run.info.run_id)
-        
-        # Run inference pipeline
-        # 1. BERT encoding
-        # Tokenize input text
-        inputs = tokenizer(processed_files[0], padding=True, truncation=True, max_length=128, return_tensors="pt")
+
+        # 4. Run original inference pipeline
+
+        # 4.1 Load processed track metadata
+        json_path = os.path.join(processed_dir, "track_texts.json") 
+        with open(json_path, "r", encoding="utf-8") as f:
+            track_metadata = json.load(f)
+        print(f"Loaded {len(track_metadata)} tracks from {json_path}")
+
+        # 4.2 BERT encoding
+        texts = [item["text"] for item in track_metadata]
+        inputs = tokenizer(texts, padding=True, truncation=True,
+                           max_length=128, return_tensors="pt")
         with torch.no_grad():
             bert_output = models['bert'](**inputs).last_hidden_state[:, 0, :].cpu().numpy()
-        
-        # 2. Matrix Factorization
-        # Convert BERT output to user-item format
+        print(f"Encoded {len(texts)} tracks with BERT")
+
+        # 4.3 Matrix Factorization
+        print("starting matrix factorization...")
         mf_input = torch.tensor(bert_output, dtype=torch.float32)
         mf_output = models['mf'].predict(mf_input)
-        
-        # 3. MLP
-        # Convert MF output to tensor
+        print(f"Finished MF on {mf_input.shape[0]} tracks")
+
+        # 4.4 MLP
+        print("starting mlp...")
         mlp_input = torch.tensor(mf_output, dtype=torch.float32)
         mlp_output = models['mlp'](mlp_input)
-        
-        # 4. LLARA
-        # Convert MLP output to tensor
-        llara_input = torch.tensor(mlp_output, dtype=torch.float32)
+        print(f"Finished MLP on {mlp_input.shape[0]} tracks")
+
+        # 4.5 LLARA
+        print("starting llara...")
+        llara_input  = torch.tensor(mlp_output, dtype=torch.float32)
         final_output = models['llara'](llara_input)
-        
-        # Convert output to original format
+        print(f"Finished LLARA on {llara_input.shape[0]} tracks")
+
+        # 5. Branch: use Triton if enabled
+        if USE_TRITON:
+            # convert to numpy
+            output_np = final_output.cpu().numpy() 
+            # prepare Triton input
+            inp = InferInput("input_embeddings", output_np.shape, "FP32")
+            inp.set_data_from_numpy(output_np.astype(np.float32))
+            # specify Triton output
+            out = InferRequestedOutput("scores", binary_data=False)
+            # perform Triton inference
+            triton_res = triton_client.infer(
+                model_name="music_rec",
+                inputs=[inp],
+                outputs=[out]
+            )
+            # extract Triton predictions
+            predictions = triton_res.as_numpy("scores")[0].tolist()
+        else:
+            # bypass Triton, return raw output
+            predictions = final_output.cpu().tolist() 
+
+        # 6. Save and return output JSON
         output_data = {
             "request_id": request_id,
-            "predictions": final_output.tolist()
+            "predictions": predictions
         }
-        
-        # Save output JSON
         output_path = f"/mnt/object/inference/output_{request_id}.json"
         with open(output_path, 'w') as f:
             json.dump(output_data, f)
-        
+        print(f"Saved output to {output_path}")
+
         return JSONResponse(content=output_data)
-        
+
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e)) 
+        raise HTTPException(status_code=500, detail=str(e))

--- a/inference/inference_api.py
+++ b/inference/inference_api.py
@@ -18,7 +18,11 @@ from data_processing.data_preprocess import process_data
 
 from tritonclient.http import InferenceServerClient, InferInput, InferRequestedOutput
 
+from prometheus_fastapi_instrumentator import Instrumentator
+
 app = FastAPI(title="Music Recommendation")
+
+Instrumentator().instrument(app).expose(app)
 
 # Mount static files and templates
 app.mount("/static", StaticFiles(directory="static"), name="static")

--- a/inference/models/config.pbtxt
+++ b/inference/models/config.pbtxt
@@ -1,0 +1,28 @@
+name: "music_rec"
+backend: "onnxruntime"
+max_batch_size: 16
+
+input [
+  {
+    name: "input_embeddings" 
+    data_type: TYPE_FP32
+    dims: [128]                
+  }
+]
+
+output [
+  {
+    name: "scores"         
+    data_type: TYPE_FP32
+    dims: [100]                
+  }
+]
+
+instance_group [
+  { count: 1 kind: KIND_GPU gpus: [0] }
+]
+
+dynamic_batching {
+  preferred_batch_size: [4, 8, 16]
+  max_queue_delay_microseconds: 100
+}

--- a/inference/prometheus.yml
+++ b/inference/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'inference-api'
+    static_configs:
+      - targets: ['inference_api:8080']

--- a/inference/requirements.txt
+++ b/inference/requirements.txt
@@ -11,3 +11,4 @@ scikit-learn==1.3.0
 pandas==2.0.3
 numpy==1.24.3 
 tritonclient[http]==2.29.0
+prometheus-fastapi-instrumentator==6.1.0

--- a/inference/requirements.txt
+++ b/inference/requirements.txt
@@ -5,7 +5,7 @@ jinja2==3.1.2
 aiofiles==23.2.1
 mlflow==2.7.1
 boto3==1.28.38
-torch==2.0.1
+torch==2.2.2
 transformers==4.30.2
 scikit-learn==1.3.0
 pandas==2.0.3

--- a/inference/requirements.txt
+++ b/inference/requirements.txt
@@ -10,3 +10,4 @@ transformers==4.30.2
 scikit-learn==1.3.0
 pandas==2.0.3
 numpy==1.24.3 
+tritonclient[http]==2.29.0

--- a/load_to_staging.sh
+++ b/load_to_staging.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Minimal load-to-staging script (no retraining)
+
+set -e
+
+IMAGE_REPO="registry.kube-system.svc.cluster.local:5000/mlops-app"
+IMAGE_TAG="staging-$(date +%Y%m%d%H%M%S)"
+HELM_VALUES="k8s/staging/values.yaml"
+
+echo "[1/4] Registering existing model..."
+python3 train/register_model.py
+
+echo "[2/4] Building Docker image..."
+docker build -t ${IMAGE_REPO}:${IMAGE_TAG} -f inference/Dockerfile.staging inference/
+
+echo "[3/4] Pushing Docker image..."
+docker push ${IMAGE_REPO}:${IMAGE_TAG}
+
+echo "[4/4] Updating Helm image tag..."
+sed -i.bak "s|tag: .*|tag: ${IMAGE_TAG}|" ${HELM_VALUES}
+
+echo "Done! Now commit and push to deploy:"
+echo "git commit -am 'Deploy existing model ${IMAGE_TAG}' && git push"

--- a/train/register_model.py
+++ b/train/register_model.py
@@ -1,0 +1,25 @@
+# train/register_model.py
+import mlflow
+
+# Connect to your MLflow tracking server
+mlflow.set_tracking_uri("http://129.114.25.37:8000")
+MODEL_NAME = "LLaRA-Rec-Model"
+
+def get_latest_run():
+    """
+    Return the latest finished run ID from the 'llara-classifier' experiment.
+    """
+    runs = mlflow.search_runs(
+        experiment_names=["llara-classifier"],
+        filter_string="status = 'FINISHED'",
+        order_by=["start_time DESC"]
+    )
+    return runs.iloc[0].run_id
+
+# Register the model from the latest run into the MLflow model registry
+run_id = get_latest_run()
+model_uri = f"runs:/{run_id}/models/llara_model.pt"
+mlflow.register_model(model_uri=model_uri, name=MODEL_NAME)
+
+print(f"Registered model from run {run_id} as {MODEL_NAME}")
+ 


### PR DESCRIPTION
1. model evaluation: (add prepare_data.py，benchmark_models.py)

(1)Usage:
ssh -i ~/Downloads/project_key cc@129.114.25.37

cd ~/workspace/MLOps_Spring_2025

source venv/bin/activate

python inference/evaluation/export_onnx.py

cd inference/evaluation
python prepare_data.py

python benchmark_models.py

(2)Output:
In the terminal, observe the output of Model size / Accuracy / Latency (P50/P95) / Throughput for each stage including PyTorch baseline, ONNX baseline, graph-opt, dynamic/static quant, CUDA/TensorRT/OpenVINO.

2. system evaluation:(add export_onnx.py, requirements.txt,inference_api.py, docker-compose-inference.yml,models/music_rec/config.pdtxt,models/music_rec/1/model.onnx,evaluation/gen_input.py,evaluation/post.lua,evaluation/run_bench.sh)

(1)usage:
cd MLOPS_SPRING_2025/inference
python export_onnx.py

cd MLOPS_SPRING_2025/inference
docker-compose -f docker-compose-inference.yml up -d --build

cd MLOPS_SPRING_2025/inference/evaluation
python gen_input.py

chmod +x run_bench.sh
./run_bench.sh | tee bench_results.log

curl localhost:8005/metrics | grep -E "nv_inference_server_queue|nv_inference_server_compute_infer"
docker stats inference_api triton
watch -n1 nvidia-smi

3. load data to staging:(add register_model.py, Dockerfile.staging, load_to_staging.sh )
(1) usage
chmod +x load_to_staging.sh 

./load_to_staging.sh 

git commit -am "Deploy existing model to staging"
git push

4.online evaluation:(modify docker-compose-inference.yml,inference_api.py,prometheus.yml,prometheus.yml,requirements.txt,gen_real_examples.py,simulate_users.py)
(1) usage
cd inference
docker compose -f docker-compose-inference.yml up –build

python inference/evaluation/gen_real_examples.py

python inference/evaluation/simulate_users.py
